### PR TITLE
Exclude cancelled orders from orders staging model

### DIFF
--- a/models/orders_stg/orders_stg.sql
+++ b/models/orders_stg/orders_stg.sql
@@ -10,4 +10,4 @@ SELECT
 FROM
 	{{ ref('orders') }}
 WHERE
-	Status != 'cancelled'
+	Status NOT IN ('cancelled', 'pending')

--- a/models/orders_stg/orders_stg.sql
+++ b/models/orders_stg/orders_stg.sql
@@ -9,3 +9,5 @@ SELECT
 	Status
 FROM
 	{{ ref('orders') }}
+WHERE
+	Status != 'cancelled'


### PR DESCRIPTION
'Removes cancelled orders from reporting to improve metric accuracy for the business.'